### PR TITLE
Allow options to be passed to the xml parser, unit tests

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,4 +1,6 @@
 {
+  "disallowSemicolons": true,
+  "disallowUnusedVariables": true,
   "disallowEmptyBlocks": true,
   "disallowMixedSpacesAndTabs": true,
   "disallowImplicitTypeConversion": [
@@ -55,6 +57,11 @@
     "!=",
     "!=="
   ],
+  "requireSpacesInAnonymousFunctionExpression": {
+    "beforeOpeningRoundBrace": true,
+    "beforeOpeningCurlyBrace": true
+  },
+  "requireSpacesInsideObjectBrackets": "allButNested",
   "requireLineBreakAfterVariableAssignment": true,
   "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties",
   "requireSpacesInForStatement": true,

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 node_modules/
 .idea/
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "6"
+  - "4"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Node-Recurly
 ===============
-[![Build Status](https://travis-ci.org/geoffdutton/recurly-js.svg?branch=master)](https://travis-ci.org/geoffdutton/recurly-js)
+[![Build Status](https://travis-ci.org/geoffdutton/recurly-js.svg)](https://travis-ci.org/geoffdutton/recurly-js)
 
 This is a fork of original `node-recurly` library by [Rob Righter](https://github.com/robrighter) for the recurly recurring billing service. 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Node-Recurly
 ===============
+[![Build Status](https://travis-ci.org/geoffdutton/recurly-js.svg?branch=master)](https://travis-ci.org/geoffdutton/recurly-js)
 
 This is a fork of original `node-recurly` library by [Rob Righter](https://github.com/robrighter) for the recurly recurring billing service. 
 

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/recurly');
+module.exports = require('./lib/recurly')

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,20 +1,30 @@
-'use strict';
+'use strict'
 
-var https = require('https');
-var pjson = require('../package.json');
-var Xml2js = require('xml2js');
-var parser = new Xml2js.Parser({explicitArray: false});
+const https = require('https')
+const pjson = require('../package.json')
+const Xml2js = require('xml2js')
 
 exports.create = function (config) {
-  config.RECURLY_HOST = config.SUBDOMAIN + '.recurly.com';
+  config.RECURLY_HOST = config.SUBDOMAIN + '.recurly.com'
+  const xml2jsOptions = config.XML2JS_OPTIONS || null
+  if(xml2jsOptions && Array.isArray(xml2jsOptions.valueProcessors)) {
+    xml2jsOptions.valueProcessors = xml2jsOptions.valueProcessors.map((maybeFunction) => {
+      if(typeof maybeFunction === 'string' && typeof Xml2js.processors[maybeFunction] === 'function') {
+        return Xml2js.processors[maybeFunction]
+      }
+      return maybeFunction
+    })
+  }
+
+  const parser = new Xml2js.Parser(config.XML2JS_OPTIONS || { explicitArray: false })
   return {
 
     request: function (route, callback, data) {
-      var endpoint = route[0];
-      var method = route[1];
-      var headers = route[2];
-      var that = this;
-      var options = {
+      const endpoint = route[0]
+      const method = route[1]
+      const headers = route[2]
+      const that = this
+      const options = {
         host: config.RECURLY_HOST,
         port: 443,
         path: endpoint,
@@ -25,134 +35,135 @@ exports.create = function (config) {
           'Content-Length': (data) ? Buffer.byteLength(data, 'utf8') : 0,
           'User-Agent': 'recurly-js/' + pjson.version
         }
-      };
+      }
 
       if (headers) {
-        for (var p in headers) {
-          if (!headers.hasOwnProperty(p)) continue;
+        for (const p in headers) {
+          if (!headers.hasOwnProperty(p)) {
+            continue
+          }
 
-          options.headers[p] = headers[p];
+          options.headers[p] = headers[p]
         }
       }
 
       if (method.toLowerCase() === 'post' || method.toLowerCase() === 'put') {
-        options.headers['Content-Type'] = 'application/xml';
-        that.debug(data);
+        options.headers['Content-Type'] = 'application/xml'
+        that.debug(data)
       }
-      that.debug(options);
-      var req = https.request(options, function (res) {
+      that.debug(options)
+      const req = https.request(options, function (res) {
 
-        var responsedata = '';
+        let responsedata = ''
         res.on('data', function (d) {
-          responsedata += d;
-        });
+          responsedata += d
+        })
         res.on('end', function () {
-          responsedata = that.trim(responsedata);
-          that.debug('Response is: ' + res.statusCode);
-          that.debug(responsedata);
+          responsedata = that.trim(responsedata)
+          that.debug('Response is: ' + res.statusCode)
+          that.debug(responsedata)
           try {
             // 200–299 success
             if (res.statusCode >= 200 && res.statusCode <= 299) {
               if (responsedata === '') {
-                return _cb(res);
+                return _cb(res)
               }
               else if (options.headers.Accept !== 'application/xml') {
-                return _cb(res, null, responsedata);
+                return _cb(res, null, responsedata)
               }
               return parser.parseString(responsedata, function (err, result) {
-                return _cb(res, null, result);
-              });
+                return _cb(res, null, result)
+              })
             }
             // 400–499 client request errors
             // 500–599 server errors
             if ([404, 412, 422, 500].indexOf(res.statusCode) !== -1) {
               return parser.parseString(responsedata, function (err, result) {
-                return _cb(res, result);
-              });
+                return _cb(res, result)
+              })
             }
             if (res.statusCode >= 400) {
-              return _cb(res, responsedata);
+              return _cb(res, responsedata)
             }
           }
           catch (e) {
-            return _cb(null, e);
+            return _cb(null, e)
           }
-        });
-      });
+        })
+      })
       if (data) {
-        req.write(data);
+        req.write(data)
       }
-      req.end();
+      req.end()
       req.on('error', function (e) {
-        return _cb(null, e);
-      });
+        return _cb(null, e)
+      })
       // fallback for backward compatibility
       function _cb(res, err, data) {
         // callback objects acquired from parent scope
         if (typeof callback === 'undefined') {
-          throw new Error('Missing argument: callback function');
+          throw new Error('Missing argument: callback function')
         }
         if (typeof callback !== 'function') {
-          throw new Error('Callback should be a function');
+          throw new Error('Callback should be a function')
         }
         if (callback.length === 2) {
           if (err) {
-            return callback(_wrapResponse(res, err));
+            return callback(_wrapResponse(res, err))
           }
-          return callback(null, _wrapResponse(res, data));
+          return callback(null, _wrapResponse(res, data))
 
         }
         // backward compatibility for not node.js style callbacks
         // TBD: skip in next version?
         else if (callback.length === 1) {
-          var toreturn = {status: 'ok', data: '', headers: res ? res.headers : null};
+          const toreturn = { status: 'ok', data: '', headers: res ? res.headers : null }
           if (err) {
-            toreturn.status = 'error';
+            toreturn.status = 'error'
             if (!res || err === Error || err instanceof Error) {
-              toreturn.description = err;
+              toreturn.description = err
             } else if (res.statusCode >= 400) {
-              toreturn.data = res.statusCode;
-              toreturn.additional = err;
+              toreturn.data = res.statusCode
+              toreturn.additional = err
             } else {
-              toreturn.data = err;
+              toreturn.data = err
             }
-            return callback(toreturn);
+            return callback(toreturn)
           }
-          toreturn.data = data;
-          toreturn.description = res.statusCode;
-          return callback(toreturn);
+          toreturn.data = data
+          toreturn.description = res.statusCode
+          return callback(toreturn)
         }
       }
 
       function _wrapResponse(res, data) {
         if (!res) {
-          return {data: data && data.stack ? data.stack : data};
+          return { data: data && data.stack ? data.stack : data }
         }
         return {
           statusCode: res.statusCode,
           headers: res.headers,
           data: data
-        };
+        }
       }
     },
 
     debug: function (s) {
       if (config.DEBUG) {
-        console.log(s);
+        console.log(s)
       }
     },
 
     trim: function (str) {
-      str = str.replace(/^\s+/, '');
-      for (var i = str.length - 1; i >= 0; i--) {
+      str = str.replace(/^\s+/, '')
+      for (let i = str.length - 1; i >= 0; i--) {
         if (/\S/.test(str.charAt(i))) {
-          str = str.substring(0, i + 1);
-          break;
+          str = str.substring(0, i + 1)
+          break
         }
       }
-      return str;
+      return str
     }
-
-  };
-};
+  }
+}
 

--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -1,385 +1,385 @@
-'use strict';
+'use strict'
 
-var js2xmlparser = require('js2xmlparser');
-var Client = require('./client');
-var utils = require('./utils');
-var router = require('./routes/');
+const js2xmlparser = require('js2xmlparser')
+const Client = require('./client')
+const utils = require('./utils')
+const router = require('./routes/')
 
-module.exports = function(config) {
-  var routes = router.routes(config.API_VERSION ? config.API_VERSION : '2');
-  var t = Client.create(config);
+module.exports = function (config) {
+  const routes = router.routes(config.API_VERSION ? config.API_VERSION : '2')
+  const t = Client.create(config)
   this.accounts = {
-    list: function(callback, filter) {
-      t.request(utils.addQueryParams(routes.accounts.list, filter), callback);
+    list: function (callback, filter) {
+      t.request(utils.addQueryParams(routes.accounts.list, filter), callback)
     },
-    get: function(accountcode, callback) {
+    get: function (accountCode, callback) {
       t.request(utils.addParams(routes.accounts.get, {
-        account_code: accountcode
-      }), callback);
+        account_code: accountCode
+      }), callback)
     },
-    create: function(details, callback) {
-      t.request(routes.accounts.create, callback, js2xmlparser('account', details));
+    create: function (details, callback) {
+      t.request(routes.accounts.create, callback, js2xmlparser('account', details))
     },
-    update: function(accountcode, details, callback) {
+    update: function (accountCode, details, callback) {
       t.request(utils.addParams(routes.accounts.update, {
-        account_code: accountcode
-      }), callback, js2xmlparser('account', details));
+        account_code: accountCode
+      }), callback, js2xmlparser('account', details))
     },
-    close: function(accountcode, callback) {
+    close: function (accountCode, callback) {
       t.request(utils.addParams(routes.accounts.close, {
-        account_code: accountcode
-      }), callback);
+        account_code: accountCode
+      }), callback)
     },
-    reopen: function(accountcode, callback) {
+    reopen: function (accountCode, callback) {
       t.request(utils.addParams(routes.accounts.reopen, {
-        account_code: accountcode
-      }), callback);
+        account_code: accountCode
+      }), callback)
     },
-    notes: function(accountcode, callback) {
+    notes: function (accountCode, callback) {
       t.request(utils.addParams(routes.accounts.notes, {
-        account_code: accountcode
-      }), callback);
+        account_code: accountCode
+      }), callback)
     }
-  };
+  }
 
   this.adjustments = {
-    list: function(accountcode, callback) {
+    list: function (accountCode, callback) {
       t.request(utils.addParams(routes.adjustments.list, {
-        account_code: accountcode
-      }), callback);
+        account_code: accountCode
+      }), callback)
     },
-    get: function(uuid, callback) {
+    get: function (uuid, callback) {
       t.request(utils.addParams(routes.adjustments.get, {
         uuid: uuid
-      }), callback);
+      }), callback)
     },
-    create: function(accountcode, details, callback) {
+    create: function (accountCode, details, callback) {
       t.request(utils.addParams(routes.adjustments.create, {
-        account_code: accountcode
-      }), callback, js2xmlparser('adjustment', details));
+        account_code: accountCode
+      }), callback, js2xmlparser('adjustment', details))
     },
-    remove: function(uuid, callback) {
+    remove: function (uuid, callback) {
       t.request(utils.addParams(routes.adjustments.remove, {
         uuid: uuid
-      }), callback);
+      }), callback)
     }
-  };
+  }
 
 
   this.billingInfo = {
-    update: function(accountcode, details, callback) {
+    update: function (accountCode, details, callback) {
       t.request(utils.addParams(routes.billingInfo.update, {
-        account_code: accountcode
-      }), callback, js2xmlparser('billing_info', details));
+        account_code: accountCode
+      }), callback, js2xmlparser('billing_info', details))
     },
-    get: function(accountcode, callback) {
+    get: function (accountCode, callback) {
       t.request(utils.addParams(routes.billingInfo.get, {
-        account_code: accountcode
-      }), callback);
+        account_code: accountCode
+      }), callback)
     },
-    remove: function(accountcode, callback) {
+    remove: function (accountCode, callback) {
       t.request(utils.addParams(routes.billingInfo.remove, {
-        account_code: accountcode
-      }), callback);
+        account_code: accountCode
+      }), callback)
     }
-  };
+  }
 
   this.coupons = {
-    list: function(callback, filter) {
-      t.request(utils.addQueryParams(routes.coupons.list, filter), callback);
+    list: function (callback, filter) {
+      t.request(utils.addQueryParams(routes.coupons.list, filter), callback)
     },
-    get: function(couponcode, callback) {
+    get: function (couponcode, callback) {
       t.request(utils.addParams(routes.coupons.get, {
         coupon_code: couponcode
-      }), callback);
+      }), callback)
     },
-    create: function(details, callback) {
-      t.request(routes.coupons.create, callback, js2xmlparser('coupon', details));
+    create: function (details, callback) {
+      t.request(routes.coupons.create, callback, js2xmlparser('coupon', details))
     },
-    deactivate: function(couponcode, callback) {
+    deactivate: function (couponcode, callback) {
       t.request(utils.addParams(routes.coupons.deactivate, {
         coupon_code: couponcode
-      }), callback);
+      }), callback)
     }
-  };
+  }
 
   this.couponRedemption = {
-    redeem: function(couponcode, details, callback) {
+    redeem: function (couponcode, details, callback) {
       t.request(utils.addParams(routes.couponRedemption.redeem, {
         coupon_code: couponcode
-      }), callback, js2xmlparser('redemption', details));
+      }), callback, js2xmlparser('redemption', details))
     },
-    get: function(accountcode, callback) {
+    get: function (accountCode, callback) {
       t.request(utils.addParams(routes.couponRedemption.get, {
-        account_code: accountcode
-      }), callback);
+        account_code: accountCode
+      }), callback)
     },
-    getAll: function(accountcode, callback) {
+    getAll: function (accountCode, callback) {
       t.request(utils.addParams(routes.couponRedemption.getAll, {
-        account_code: accountcode
-      }), callback);
+        account_code: accountCode
+      }), callback)
     },
-    remove: function(accountcode, callback) {
+    remove: function (accountCode, callback) {
       t.request(utils.addParams(routes.couponRedemption.remove, {
-        account_code: accountcode
-      }), callback);
+        account_code: accountCode
+      }), callback)
     },
-    getByInvoice: function(invoicenumber, callback) {
+    getByInvoice: function (invoicenumber, callback) {
       t.request(utils.addParams(routes.couponRedemption.getByInvoice, {
         invoice_number: invoicenumber
-      }), callback);
+      }), callback)
     }
-  };
+  }
 
   this.invoices = {
-    list: function(callback, filter) {
-      t.request(utils.addQueryParams(routes.invoices.list, filter), callback);
+    list: function (callback, filter) {
+      t.request(utils.addQueryParams(routes.invoices.list, filter), callback)
     },
-    listByAccount: function(accountcode, callback, filter) {
+    listByAccount: function (accountCode, callback, filter) {
       t.request(
         utils.addParams(
           utils.addQueryParams(routes.invoices.listByAccount, filter), {
-            account_code: accountcode
+            account_code: accountCode
           }), callback)
     },
-    get: function(invoicenumber, callback) {
+    get: function (invoicenumber, callback) {
       t.request(utils.addParams(routes.invoices.get, {
         invoice_number: invoicenumber
-      }), callback);
+      }), callback)
     },
-    create: function(accountcode, details, callback) {
+    create: function (accountCode, details, callback) {
       t.request(utils.addParams(routes.invoices.create, {
-        account_code: accountcode
-      }), callback, js2xmlparser('invoice', details));
+        account_code: accountCode
+      }), callback, js2xmlparser('invoice', details))
     },
-    preview: function(accountcode, callback) {
+    preview: function (accountCode, callback) {
       t.request(utils.addParams(routes.invoices.preview, {
-        account_code: accountcode
-      }), callback);
+        account_code: accountCode
+      }), callback)
     },
-    refundLineItems: function(invoicenumber, details, callback) {
+    refundLineItems: function (invoicenumber, details, callback) {
       t.request(utils.addParams(routes.invoices.refundLineItems, {
         invoice_number: invoicenumber
-      }), callback, js2xmlparser('invoice', details));
+      }), callback, js2xmlparser('invoice', details))
     },
-    refundOpenAmount: function(invoicenumber, details, callback) {
+    refundOpenAmount: function (invoicenumber, details, callback) {
       t.request(utils.addParams(routes.invoices.refundOpenAmount, {
         invoice_number: invoicenumber
-      }), callback, js2xmlparser('invoice', details));
+      }), callback, js2xmlparser('invoice', details))
     },
-    markSuccessful: function(invoicenumber, callback) {
+    markSuccessful: function (invoicenumber, callback) {
       t.request(utils.addParams(routes.invoices.markSuccessful, {
         invoice_number: invoicenumber
-      }), callback);
+      }), callback)
     },
-    markFailed: function(invoicenumber, callback) {
+    markFailed: function (invoicenumber, callback) {
       t.request(utils.addParams(routes.invoices.markFailed, {
         invoice_number: invoicenumber
-      }), callback);
+      }), callback)
     },
-    enterOfflinePayment: function(invoicenumber, details, callback) {
+    enterOfflinePayment: function (invoicenumber, details, callback) {
       t.request(utils.addParams(routes.invoices.enterOfflinePayment, {
         invoice_number: invoicenumber
-      }), callback, js2xmlparser('transaction', details));
+      }), callback, js2xmlparser('transaction', details))
     },
-    exportPdf: function(invoicenumber, callback) {
+    exportPdf: function (invoicenumber, callback) {
       t.request(utils.addParams(routes.invoices.retrievePdf, {
         invoice_number: invoicenumber
-      }), callback);
+      }), callback)
     }
-  };
+  }
 
   this.plans = {
-    list: function(callback, filter) {
-      t.request(utils.addQueryParams(routes.plans.list, filter), callback);
+    list: function (callback, filter) {
+      t.request(utils.addQueryParams(routes.plans.list, filter), callback)
     },
-    get: function(plancode, callback) {
+    get: function (plancode, callback) {
       t.request(utils.addParams(routes.plans.get, {
         plan_code: plancode
-      }), callback);
+      }), callback)
     },
-    create: function(details, callback) {
-      t.request(routes.plans.create, callback, js2xmlparser('plan', details));
+    create: function (details, callback) {
+      t.request(routes.plans.create, callback, js2xmlparser('plan', details))
     },
-    update: function(plancode, details, callback) {
+    update: function (plancode, details, callback) {
       t.request(utils.addParams(routes.plans.update, {
         plan_code: plancode
-      }), callback, js2xmlparser('plan', details));
+      }), callback, js2xmlparser('plan', details))
     },
-    remove: function(plancode, callback) {
+    remove: function (plancode, callback) {
       t.request(utils.addParams(routes.plans.remove, {
         plan_code: plancode
-      }), callback);
+      }), callback)
     }
-  };
+  }
 
   this.planAddons = {
-    list: function(plancode, callback, filter) {
+    list: function (plancode, callback, filter) {
       t.request(utils.addParams(utils.addQueryParams(routes.planAddons.list, filter), {
         plan_code: plancode
-      }), callback);
+      }), callback)
     },
-    get: function(plancode, addoncode, callback) {
+    get: function (plancode, addOnCode, callback) {
       t.request(utils.addParams(routes.planAddons.get, {
         plan_code: plancode,
-        addon_code: addoncode
-      }), callback);
+        addon_code: addOnCode
+      }), callback)
     },
-    create: function(plancode, details, callback) {
+    create: function (plancode, details, callback) {
       t.request(utils.addParams(routes.planAddons.create, {
         plan_code: plancode
-      }), callback, js2xmlparser('add_on', details));
+      }), callback, js2xmlparser('add_on', details))
     },
-    update: function(plancode, addoncode, details, callback) {
+    update: function (plancode, addOnCode, details, callback) {
       t.request(utils.addParams(
         routes.planAddons.update, {
           plan_code: plancode,
-          add_on_code: addoncode
+          add_on_code: addOnCode
         }),
-        callback, js2xmlparser('add_on', details));
+        callback, js2xmlparser('add_on', details))
     },
-    remove: function(plancode, addoncode, callback) {
+    remove: function (plancode, addOnCode, callback) {
       t.request(utils.addParams(routes.planAddons.remove, {
         plan_code: plancode,
-        add_on_code: addoncode
-      }), callback);
+        add_on_code: addOnCode
+      }), callback)
     }
-  };
+  }
 
   this.subscriptions = {
-    list: function(callback, filter) {
-      t.request(utils.addQueryParams(routes.subscriptions.list, filter), callback);
+    list: function (callback, filter) {
+      t.request(utils.addQueryParams(routes.subscriptions.list, filter), callback)
     },
-    listByAccount: function(accountcode, callback) {
+    listByAccount: function (accountCode, callback) {
       t.request(utils.addParams(routes.subscriptions.listByAccount, {
-        account_code: accountcode
-      }), callback);
+        account_code: accountCode
+      }), callback)
     },
-    get: function(uuid, callback) {
+    get: function (uuid, callback) {
       t.request(utils.addParams(routes.subscriptions.get, {
         uuid: uuid
-      }), callback);
+      }), callback)
     },
-    create: function(details, callback) {
-      t.request(routes.subscriptions.create, callback, js2xmlparser('subscription', details));
+    create: function (details, callback) {
+      t.request(routes.subscriptions.create, callback, js2xmlparser('subscription', details))
     },
-    preview: function(details, callback) {
-      t.request(routes.subscriptions.preview, callback, js2xmlparser('subscription', details));
+    preview: function (details, callback) {
+      t.request(routes.subscriptions.preview, callback, js2xmlparser('subscription', details))
     },
-    update: function(uuid, details, callback) {
+    update: function (uuid, details, callback) {
       t.request(utils.addParams(routes.subscriptions.update, {
         uuid: uuid
-      }), callback, js2xmlparser('subscription', details));
+      }), callback, js2xmlparser('subscription', details))
     },
-    updateNotes: function(uuid, details, callback) {
+    updateNotes: function (uuid, details, callback) {
       t.request(utils.addParams(routes.subscriptions.updateNotes, {
         uuid: uuid
-      }), callback, js2xmlparser('subscription', details));
+      }), callback, js2xmlparser('subscription', details))
     },
-    updatePreview: function(uuid, details, callback) {
+    updatePreview: function (uuid, details, callback) {
       t.request(utils.addParams(routes.subscriptions.updatePreview, {
         uuid: uuid
-      }), callback, js2xmlparser('subscription', details));
+      }), callback, js2xmlparser('subscription', details))
     },
-    cancel: function(uuid, callback) {
+    cancel: function (uuid, callback) {
       t.request(utils.addParams(routes.subscriptions.cancel, {
         uuid: uuid
-      }), callback);
+      }), callback)
     },
-    reactivate: function(uuid, callback) {
+    reactivate: function (uuid, callback) {
       t.request(utils.addParams(routes.subscriptions.reactivate, {
         uuid: uuid
-      }), callback);
+      }), callback)
     },
-    terminate: function(uuid, refundType, callback) {
+    terminate: function (uuid, refundType, callback) {
       t.request(utils.addParams(routes.subscriptions.terminate, {
         uuid: uuid,
         refund_type: refundType
-      }), callback);
+      }), callback)
     },
-    postpone: function(uuid, nextRenewalDate, callback) {
+    postpone: function (uuid, nextRenewalDate, callback) {
       t.request(utils.addParams(routes.subscriptions.postpone, {
         uuid: uuid,
         next_renewal_date: nextRenewalDate
-      }), callback);
+      }), callback)
     }
-  };
+  }
 
   this.transactions = {
-    list: function(callback, filter) {
-      t.request(utils.addQueryParams(routes.transactions.list, filter), callback);
+    list: function (callback, filter) {
+      t.request(utils.addQueryParams(routes.transactions.list, filter), callback)
     },
-    listByAccount: function(accountCode, callback, filter) {
+    listByAccount: function (accountCode, callback, filter) {
       t.request(
         utils.addParams(
           utils.addQueryParams(routes.transactions.listByAccount, filter), {
             account_code: accountCode
           }),
-        callback);
+        callback)
     },
-    get: function(id, callback) {
+    get: function (id, callback) {
       t.request(utils.addParams(routes.transactions.get, {
         'id': id
-      }), callback);
+      }), callback)
     },
-    create: function(details, callback) {
-      t.request(routes.transactions.create, callback, js2xmlparser('transaction', details));
+    create: function (details, callback) {
+      t.request(routes.transactions.create, callback, js2xmlparser('transaction', details))
     },
-    refund: function(id, callback, amount) {
-      var route = utils.addParams(routes.transactions.refund, {
+    refund: function (id, callback, amount) {
+      let route = utils.addParams(routes.transactions.refund, {
         id: id
-      });
+      })
       if (amount) {
         route = utils.addQueryParams(route, {
           amount_in_cents: amount
-        });
+        })
       }
-      t.request(route, callback);
+      t.request(route, callback)
     }
-  };
+  }
 
   this.usageRecords = {
-    list: function(subscription_uuid, add_on_code, callback, filter) {
+    list: function (subscriptionUuid, addOnCode, callback, filter) {
       t.request(utils.addParams(utils.addQueryParams(routes.usageRecords.list, filter), {
-        subscription_uuid: subscription_uuid,
-        add_on_code: add_on_code
-      }), callback);
+        subscription_uuid: subscriptionUuid,
+        add_on_code: addOnCode
+      }), callback)
     },
-    lookup: function(subscription_uuid, add_on_code, usage_id, callback) {
+    lookup: function (subscriptionUuid, addOnCode, usageId, callback) {
       t.request(utils.addParams(routes.usageRecords.lookup, {
-        subscription_uuid: subscription_uuid,
-        add_on_code: add_on_code,
-        usage_id: usage_id
-      }), callback);
+        subscription_uuid: subscriptionUuid,
+        add_on_code: addOnCode,
+        usage_id: usageId
+      }), callback)
     },
-    log: function(subscription_uuid, add_on_code, details, callback) {
+    log: function (subscriptionUuid, addOnCode, details, callback) {
       t.request(utils.addParams(routes.usageRecords.log, {
-        subscription_uuid: subscription_uuid,
-        add_on_code: add_on_code
-      }), callback, js2xmlparser('usage', details));
+        subscription_uuid: subscriptionUuid,
+        add_on_code: addOnCode
+      }), callback, js2xmlparser('usage', details))
     },
-    update: function(subscription_uuid, add_on_code, usage_id, details, callback) {
+    update: function (subscriptionUuid, addOnCode, usageId, details, callback) {
       t.request(utils.addParams(routes.usageRecords.update, {
-        subscription_uuid: subscription_uuid,
-        add_on_code: add_on_code,
-        usage_id: usage_id
-      }), callback, js2xmlparser('usage', details));
+        subscription_uuid: subscriptionUuid,
+        add_on_code: addOnCode,
+        usage_id: usageId
+      }), callback, js2xmlparser('usage', details))
     },
-    delete: function(subscription_uuid, add_on_code, usage_id, callback) {
+    delete: function (subscriptionUuid, addOnCode, usageId, callback) {
       t.request(utils.addParams(routes.usageRecords.delete, {
-        subscription_uuid: subscription_uuid,
-        add_on_code: add_on_code,
-        usage_id: usage_id
-      }), callback);
+        subscription_uuid: subscriptionUuid,
+        add_on_code: addOnCode,
+        usage_id: usageId
+      }), callback)
     }
-  };
+  }
 
-  this.api = function(options, callback) {
-    var route = [options.url, options.method || 'GET', options.headers];
-    var body;
+  this.api = function (options, callback) {
+    const route = [options.url, options.method || 'GET', options.headers]
+    let body
     if (options.bodyRoot && options.body) {
       body = js2xmlparser(options.bodyRoot, options.body)
     }
-    t.request(route, callback, body);
+    t.request(route, callback, body)
   }
-};
+}

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -1,14 +1,14 @@
-'use strict';
+'use strict'
 
-var routes = {
+const routes = {
   'v2': require('./v2')
-};
+}
 
 
 exports.routes = function (version) {
   if (routes['v' + version]) {
-    return routes['v' + version];
+    return routes['v' + version]
   } else {
-    throw new Error('The API version v' + version + ' is not available!');
+    throw new Error('The API version v' + version + ' is not available!')
   }
-};
+}

--- a/lib/routes/v2.js
+++ b/lib/routes/v2.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 exports.accounts = {
   list: ['/v2/accounts', 'GET'],
@@ -21,14 +21,14 @@ exports.billingInfo = {
   get: ['/v2/accounts/:account_code/billing_info', 'GET'],
   update: ['/v2/accounts/:account_code/billing_info', 'PUT'],
   remove: ['/v2/accounts/:account_code/billing_info', 'DELETE']
-};
+}
 
 exports.coupons = {
   list: ['/v2/coupons', 'GET'],
   get: ['/v2/coupons/:coupon_code', 'GET'],
   create: ['/v2/coupons', 'POST'],
   deactivate: ['/v2/coupons/:coupon_code', 'DELETE']
-};
+}
 
 exports.couponRedemption = {
   redeem: ['/v2/coupons/:coupon_code/redeem', 'POST'],
@@ -36,7 +36,7 @@ exports.couponRedemption = {
   getAll: ['/v2/accounts/:account_code/redemptions', 'GET'],
   remove: ['/v2/accounts/:account_code/redemption', 'DELETE'],
   getByInvoice: ['/v2/invoices/:invoice_number/redemption', 'GET']
-};
+}
 
 exports.invoices = {
   list: ['/v2/invoices', 'GET'],
@@ -49,7 +49,7 @@ exports.invoices = {
   markSuccessful: ['/v2/invoices/:invoice_number/mark_successful', 'PUT'],
   markFailed: ['/v2/invoices/:invoice_number/mark_failed', 'PUT'],
   enterOfflinePayment: ['/v2/invoices/:invoice_number/transactions', 'POST'],
-  retrievePdf: ['/v2/invoices/:invoice_number', 'GET', {'Accept': 'application/pdf'}]
+  retrievePdf: ['/v2/invoices/:invoice_number', 'GET', { 'Accept': 'application/pdf' }]
 }
 
 exports.plans = {
@@ -58,7 +58,7 @@ exports.plans = {
   create: ['/v2/plans', 'POST'],
   update: ['/v2/plans/:plan_code', 'PUT'],
   remove: ['/v2/plans/:plan_code', 'DELETE']
-};
+}
 
 exports.planAddons = {
   list: ['/v2/plans/:plan_code/add_ons', 'GET'],
@@ -66,7 +66,7 @@ exports.planAddons = {
   create: ['/v2/plans/:plan_code/add_ons', 'POST'],
   update: ['/v2/plans/:plan_code/add_ons/:add_on_code', 'PUT'],
   remove: ['/v2/plans/:plan_code/add_ons/:add_on_code', 'DELETE']
-};
+}
 
 exports.subscriptions = {
   list: ['/v2/subscriptions', 'GET'],

--- a/lib/transparent.js
+++ b/lib/transparent.js
@@ -1,248 +1,248 @@
-'use strict';
+'use strict'
 
-var crypto = require('crypto');
-var Tools = require('./tools');
+const crypto = require('crypto')
+const Tools = require('./tools')
 
 module.exports = function (config) {
 
-  var t = new Tools(config);
+  const t = new Tools(config)
 
-  var TRANSPARENT_POST_BASE_URL = config.RECURLY_BASE_URL + '/transparent/' + config.SUBDOMAIN;
-  var BILLING_INFO_URL = TRANSPARENT_POST_BASE_URL + '/billing_info';
-  var SUBSCRIBE_URL = TRANSPARENT_POST_BASE_URL + '/subscription';
-  var TRANSACTION_URL = TRANSPARENT_POST_BASE_URL + '/transaction';
+  const TRANSPARENT_POST_BASE_URL = config.RECURLY_BASE_URL + '/transparent/' + config.SUBDOMAIN
+  const BILLING_INFO_URL = TRANSPARENT_POST_BASE_URL + '/billing_info'
+  const SUBSCRIBE_URL = TRANSPARENT_POST_BASE_URL + '/subscription'
+  const TRANSACTION_URL = TRANSPARENT_POST_BASE_URL + '/transaction'
 
-  t.debug('============================');
-  t.debug(TRANSPARENT_POST_BASE_URL);
-  t.debug(BILLING_INFO_URL);
-  t.debug(SUBSCRIBE_URL);
-  t.debug(TRANSACTION_URL);
-  t.debug('============================');
+  t.debug('============================')
+  t.debug(TRANSPARENT_POST_BASE_URL)
+  t.debug(BILLING_INFO_URL)
+  t.debug(SUBSCRIBE_URL)
+  t.debug(TRANSACTION_URL)
+  t.debug('============================')
 
   this.billingInfoUrl = function () {
-    return BILLING_INFO_URL;
-  };
+    return BILLING_INFO_URL
+  }
   this.subscribeUrl = function () {
-    return SUBSCRIBE_URL;
-  };
+    return SUBSCRIBE_URL
+  }
   this.transactionUrl = function () {
-    return TRANSACTION_URL;
-  };
+    return TRANSACTION_URL
+  }
 
   this.hidden_field = function (data) {
-    return '<input type="hidden" name="data" value="' + t.htmlEscape(encodedData(data)) + '" />';
-  };
+    return '<input type="hidden" name="data" value="' + t.htmlEscape(encodedData(data)) + '" />'
+  }
 
   this.getResults = function (confirm, result, status, type, callback) {
-    validateQueryString(confirm, type, status, result);
-    t.request('/transparent/results/' + result, 'GET', callback);
-  };
+    validateQueryString(confirm, type, status, result)
+    t.request('/transparent/results/' + result, 'GET', callback)
+  }
 
   this.getFormValuesFromResult = function getFormValuesFromResult(result, type) {
-    var fields = {};
-    var errors = [];
+    const fields = {}
+    let errors = []
     t.traverse(result.data, function (key, value, parent) {
-      var shouldprint = false;
-      var toprint = '';
+      let shouldprint = false
+      let toprint = ''
       if (value instanceof Object) {
         if (Object.keys(value).length === 0) {
-          shouldprint = true;
-          toprint = '';
+          shouldprint = true
+          toprint = ''
         }
         if (Object.hasOwnProperty('@') || Object.hasOwnProperty('#')) {
-          shouldprint = true;
-          toprint = value;
+          shouldprint = true
+          toprint = value
         }
         if (value instanceof Array) {
-          shouldprint = true;
-          toprint = value;
+          shouldprint = true
+          toprint = value
         }
       }
       else if (!(value instanceof Object)) {
-        shouldprint = true;
-        toprint = value;
+        shouldprint = true
+        toprint = value
         if (key === 'error') {
-          errors.push({field: '_general', reason: value});
-          shouldprint = false;
+          errors.push({ field: '_general', reason: value })
+          shouldprint = false
         }
       }
       if (key === '@' || key === '#') {
-        shouldprint = false;
+        shouldprint = false
       }
       if (parent === '@' || parent === '#') {
-        shouldprint = false;
+        shouldprint = false
       }
 
       if (!parent) {
         switch (type) {
           case 'subscribe':
           {
-            parent = 'account';
-            break;
+            parent = 'account'
+            break
           }
           case 'billing_info':
           {
-            parent = 'billing_info';
+            parent = 'billing_info'
           }
         }
       }
 
       if (key === 'errors') {
-        shouldprint = false;
-        errors = errors.concat(processErrors(value, parent));
+        shouldprint = false
+        errors = errors.concat(processErrors(value, parent))
       }
 
       if (shouldprint) {
-        var toadd = {};
+
         try {
-          fields[parent + '[' + key + ']'] = toprint.replace(/'/g, '&apos;');
+          fields[parent + '[' + key + ']'] = toprint.replace(/'/g, '&apos;')
         }
         catch (e) {
-          t.debug('GET FIELDS: could not process: ' + parent + '[' + key + '] : ' + toprint);
+          t.debug('GET FIELDS: could not process: ' + parent + '[' + key + '] : ' + toprint)
         }
       }
-    });
-    errors = handleFuzzyLogicSpecialCases(errors);
-    return {fields: fields, errors: errors};
-  };
+    })
+    errors = handleFuzzyLogicSpecialCases(errors)
+    return { fields: fields, errors: errors }
+  }
 
   function processErrors(errors, parent) {
-    var acc = [];
-    var processSingleError = function (e) {
+    const acc = []
+    const processSingleError = function (e) {
       try {
         acc.push({
           field: parent + '[' + e['@'].field + ']',
           reason: e['#'].replace(/'/g, '&apos;')
-        });
+        })
       }
       catch (err) {
-        t.debug('Could not process listed error: ' + e);
+        t.debug('Could not process listed error: ' + e)
       }
-    };
+    }
     errors.forEach(function (item) {
       if (item instanceof Array) {
-        item.forEach(processSingleError);
+        item.forEach(processSingleError)
       }
       else {
         try {
-          processSingleError(item);
+          processSingleError(item)
         }
         catch (err) {
-          t.debug('Could not process single error: ' + item);
+          t.debug('Could not process single error: ' + item)
         }
       }
-    });
-    return acc;
+    })
+    return acc
   }
 
   function encodedData(data) {
-    verifyRequiredFields(data);
-    var queryString = makeQueryString(data);
-    var validationString = hash(queryString);
-    return validationString + '|' + queryString;
+    verifyRequiredFields(data)
+    const queryString = makeQueryString(data)
+    const validationString = hash(queryString)
+    return validationString + '|' + queryString
   }
 
   function verifyRequiredFields(params) {
     if (!params.hasOwnProperty('redirect_url')) {
-      throw 'Missing required parameter: redirect_url';
+      throw 'Missing required parameter: redirect_url'
     }
     if (!params.hasOwnProperty('account[account_code]')) {
-      throw 'Missing required parameter: account[account_code]';
+      throw 'Missing required parameter: account[account_code]'
     }
   }
 
   function makeQueryString(params) {
-    params.time = makeDate();
-    return buildQueryStringFromSortedObject(makeSortedObject(params, true));
+    params.time = makeDate()
+    return buildQueryStringFromSortedObject(makeSortedObject(params, true))
   }
 
   function makeDate() {
-    var d = new Date();
-    var addleadingzero = function (n) {
-      return n < 10 ? '0' + n : n.toString();
-    };
+    const d = new Date()
+    const addleadingzero = function (n) {
+      return n < 10 ? '0' + n : n.toString()
+    }
     return d.getUTCFullYear() + '-' +
       addleadingzero(d.getUTCMonth() + 1) + '-' +
       addleadingzero(d.getUTCDate()) + 'T' +
       addleadingzero(d.getUTCHours()) + ':' +
       addleadingzero(d.getUTCMinutes()) + ':' +
-      addleadingzero(d.getUTCSeconds()) + 'Z';
+      addleadingzero(d.getUTCSeconds()) + 'Z'
   }
 
   function hash(data) {
     //get the sha1 of the private key in binary
-    var shakey = crypto.createHash('sha1');
-    shakey.update(config.PRIVATE_KEY);
-    shakey = shakey.digest('binary');
+    let shakey = crypto.createHash('sha1')
+    shakey.update(config.PRIVATE_KEY)
+    shakey = shakey.digest('binary')
     //now make an hmac and return it as hex
-    var hmac = crypto.createHmac('sha1', shakey);
-    hmac.update(data);
-    return hmac.digest('hex');
+    const hmac = crypto.createHmac('sha1', shakey)
+    hmac.update(data)
+    return hmac.digest('hex')
     //php:  03021207ad681f2ea9b9e1fc20ac7ae460d8d988    <== Yes this sign is identical to the php version
     //node: 03021207ad681f2ea9b9e1fc20ac7ae460d8d988
   }
 
   function buildQueryStringFromSortedObject(params) {
     return params.map(function (p) {
-      return escape(p.key) + '=' + t.urlEncode(p.value);
-    }).join('&');
+      return escape(p.key) + '=' + t.urlEncode(p.value)
+    }).join('&')
   }
 
   function makeSortedObject(obj, casesensitive) {
     return Object.keys(obj).map(function (key) {
-      return {key: key, value: obj[key]};
+      return { key: key, value: obj[key] }
     }).sort(function (a, b) {
-      return (casesensitive ? a.key : a.key.toLowerCase()) > (casesensitive ? b.key : b.key.toLowerCase());
-    });
+      return (casesensitive ? a.key : a.key.toLowerCase()) > (casesensitive ? b.key : b.key.toLowerCase())
+    })
   }
 
   //Used for validating return params from Recurly
   function validateQueryString(confirm, type, status, resultKeys) {
-    var values = {
+    const values = {
       result: resultKeys,
       status: status,
       type: type
-    };
-    var queryValues = buildQueryStringFromSortedObject(makeSortedObject(values, true));
-    var hashedValues = hash(queryValues);
+    }
+    const queryValues = buildQueryStringFromSortedObject(makeSortedObject(values, true))
+    const hashedValues = hash(queryValues)
 
     if (hashedValues !== confirm) {
-      throw 'Error: Forged query string';
+      throw 'Error: Forged query string'
     }
-    return true;
+    return true
   }
 
   function handleFuzzyLogicSpecialCases(errors) {
-    var toreturn = [];
+    const toreturn = []
     errors.forEach(function (e) {
       switch (e.field) {
         case 'billing_info[verification_value]':
         {
-          toreturn.push(copyWithNewName('billing_info[credit_card][verification_value]', e));
-          toreturn.push(copyWithNewName('credit_card[verification_value]', e));
-          break;
+          toreturn.push(copyWithNewName('billing_info[credit_card][verification_value]', e))
+          toreturn.push(copyWithNewName('credit_card[verification_value]', e))
+          break
         }
         case 'credit_card[number]':
         {
-          toreturn.push(copyWithNewName('billing_info[credit_card][number]', e));
-          toreturn.push(e);
-          break;
+          toreturn.push(copyWithNewName('billing_info[credit_card][number]', e))
+          toreturn.push(e)
+          break
         }
         default:
         {
-          toreturn.push(e);
-          break;
+          toreturn.push(e)
+          break
         }
       }
-    });
-    return toreturn;
+    })
+    return toreturn
   }
 
   function copyWithNewName(name, error) {
     return {
       field: name,
       reason: error.reason
-    };
+    }
   }
 
-};
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,27 +1,29 @@
-'use strict';
+'use strict'
 
 exports.addParams = function (route, keys) {
-  var newRoute = route.slice();
-  var path = newRoute[0];
+  const newRoute = route.slice()
+  const path = newRoute[0]
   newRoute[0] = path.replace(/(:[^\/]+)/g, function () {
-    var key = arguments[0].substr(1);
-    return keys[key];
-  });
-  return newRoute;
-};
+    const key = arguments[0].substr(1)
+    return keys[key]
+  })
+  return newRoute
+}
 
 exports.addQueryParams = function (route, params) {
-  var newRoute = route.slice();
-  var _params = [];
+  const newRoute = route.slice()
+  const _params = []
   if (params) {
-    for (var prop in params) {
-      _params.push(prop + '=' + encodeURIComponent(params[prop]));
+    for (const prop in params) {
+      if(params.hasOwnProperty(prop)) {
+        _params.push(prop + '=' + encodeURIComponent(params[prop]))
+      }
     }
   }
   if (_params.length > 0) {
-    return [newRoute[0] + '?' + _params.join('&'), newRoute[1]];
+    return [newRoute[0] + '?' + _params.join('&'), newRoute[1]]
   }
   else {
-    return newRoute;
+    return newRoute
   }
-};
+}

--- a/package.json
+++ b/package.json
@@ -28,14 +28,23 @@
     "xml2js": ">= 0.4.0"
   },
   "engines": {
-    "node": ">= 0.4"
+    "node": ">= 4.2"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm run lint && mocha --recursive test/ --reporter nyan",
+    "lint": "jscs .",
+    "tdd": "mocha --recursive test/ --reporter nyan"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/umayr/recurly-js.git"
   },
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "jscs": "^3.0.7",
+    "mocha": "^3.2.0",
+    "nock-vcr-recorder": "^0.1.5",
+    "sinon": "^1.17.6"
+  }
 }

--- a/promise.js
+++ b/promise.js
@@ -1,28 +1,28 @@
-'use strict';
+'use strict'
 
-var Promise = require('bluebird');
-var Recurly = require('./');
+const Promise = require('bluebird')
+const Recurly = require('./')
 
-module.exports = function(RECURLY_CONFIG) {
-  var recurly = new Recurly(RECURLY_CONFIG);
+module.exports = function (RECURLY_CONFIG) {
+  const recurly = new Recurly(RECURLY_CONFIG)
 
-  for (var section in recurly) {
+  for (const section in recurly) {
     if (!recurly.hasOwnProperty(section)) {
-      continue;
+      continue
     }
 
-    for (var method in recurly[section]) {
+    for (const method in recurly[section]) {
       if (!recurly[section].hasOwnProperty(method)) {
-        continue;
+        continue
       }
 
       if (typeof recurly[section][method] !== 'function') {
-        continue;
+        continue
       }
-      recurly[section][method + 'Callback'] = recurly[section][method];
-      recurly[section][method] = Promise.promisify(recurly[section][method]);
+      recurly[section][method + 'Callback'] = recurly[section][method]
+      recurly[section][method] = Promise.promisify(recurly[section][method])
     }
   }
 
-  return recurly;
-};
+  return recurly
+}

--- a/test/accounts_test.js
+++ b/test/accounts_test.js
@@ -1,0 +1,50 @@
+'use strict'
+// const Promise = require('bluebird')
+const Recurly = require('../promise')
+const config = require('./config-example')
+const recurly = new Recurly(config)
+const chai = require('chai')
+const expect = chai.expect
+const should = chai.should()
+const vcr = require('./vcr_setup')
+
+describe('accounts', () => {
+  describe('#create', () => {
+    it('should create an account with only an account_code', () => {
+      return vcr.useCassette('accounts#create', () => {
+        return recurly.accounts.create({
+          account_code: 'test_account1'
+        })
+        .then((res) => {
+          expect(res.statusCode).to.equal(201)
+          expect(res.data.account.email).to.be.null
+        })
+      })
+    })
+  })
+  describe('#get', () => {
+    it('should get an existing account', () => {
+      return vcr.useCassette('accounts#get', () => {
+        return recurly.accounts.get('test_account1')
+        .then((res) => {
+          expect(res.statusCode).to.equal(200)
+        })
+      })
+    })
+
+    it('should return 404 for a non existing account', () => {
+      return vcr.useCassette('accounts#get_not_found', () => {
+        return recurly.accounts.get('not_found')
+        .then((res) => {
+          should.not.exist(res)
+        })
+        .catch((err) => {
+          expect(err.statusCode).to.equal(404)
+          const error = err.data.error
+          expect(error.symbol).to.eq('not_found')
+          expect(error.description.toLowerCase()).to.contain(`couldn't find account`)
+        })
+      })
+    })
+  })
+})

--- a/test/billingInfo_test.js
+++ b/test/billingInfo_test.js
@@ -1,0 +1,51 @@
+'use strict'
+// const Promise = require('bluebird')
+const Recurly = require('../promise')
+const config = require('./config-example')
+const recurly = new Recurly(config)
+const chai = require('chai')
+const expect = chai.expect
+const vcr = require('./vcr_setup')
+
+describe('billingInfo', () => {
+  describe('#update', () => {
+    it('should update billingInfo with a recurly token', () => {
+      return vcr.useCassette('billingInfo#update', () => {
+        return recurly.billingInfo.update('test_account1', {
+          token_id: 'be9eBzdi_t-PB9Ym9nADKg'
+        })
+        .then((res) => {
+          // it will return 201 if the billing info was created
+          expect(res.statusCode).to.equal(201)
+        })
+      })
+    })
+  })
+
+  describe('#get', () => {
+    it('should update billingInfo with a recurly token', () => {
+      return vcr.useCassette('billingInfo#get', () => {
+        return recurly.billingInfo.get('test_account1')
+        .then((res) => {
+          // it will return 201 if the billing info was created
+          expect(res.statusCode).to.equal(200)
+        })
+      })
+    })
+
+    it('should return 404 for a non existing account', () => {
+      return vcr.useCassette('billingInfo#get_not_found', () => {
+        return recurly.accounts.get('not_found')
+        .then((res) => {
+          should.not.exist(res)
+        })
+        .catch((err) => {
+          expect(err.statusCode).to.equal(404)
+          const error = err.data.error
+          expect(error.symbol).to.eq('not_found')
+          expect(error.description.toLowerCase()).to.contain(`couldn't find account`)
+        })
+      })
+    })
+  })
+})

--- a/test/cassettes/accounts#create.json
+++ b/test/cassettes/accounts#create.json
@@ -1,0 +1,40 @@
+[
+  {
+    "scope": "https://unit-test.recurly.com:443",
+    "method": "POST",
+    "path": "/v2/accounts",
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<account>\n\t<account_code>test_account1</account_code>\n</account>",
+    "status": 201,
+    "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<account href=\"https://unit-test.recurly.com/v2/accounts/test_account1\">\n  <adjustments href=\"https://unit-test.recurly.com/v2/accounts/test_account1/adjustments\"/>\n  <invoices href=\"https://unit-test.recurly.com/v2/accounts/test_account1/invoices\"/>\n  <subscriptions href=\"https://unit-test.recurly.com/v2/accounts/test_account1/subscriptions\"/>\n  <transactions href=\"https://unit-test.recurly.com/v2/accounts/test_account1/transactions\"/>\n  <account_code>test_account1</account_code>\n  <state>active</state>\n  <username nil=\"nil\"></username>\n  <email nil=\"nil\"></email>\n  <cc_emails nil=\"nil\"></cc_emails>\n  <first_name nil=\"nil\"></first_name>\n  <last_name nil=\"nil\"></last_name>\n  <company_name nil=\"nil\"></company_name>\n  <vat_number nil=\"nil\"></vat_number>\n  <address>\n    <address1 nil=\"nil\"></address1>\n    <address2 nil=\"nil\"></address2>\n    <city nil=\"nil\"></city>\n    <state nil=\"nil\"></state>\n    <zip nil=\"nil\"></zip>\n    <country nil=\"nil\"></country>\n    <phone nil=\"nil\"></phone>\n  </address>\n  <accept_language nil=\"nil\"></accept_language>\n  <hosted_login_token>85fc92131fe6dd730f3ec49232a2abf5</hosted_login_token>\n  <created_at type=\"datetime\">2016-12-13T19:41:49Z</created_at>\n  <closed_at nil=\"nil\"></closed_at>\n</account>\n",
+    "rawHeaders": [
+      "Date",
+      "Tue, 13 Dec 2016 19:41:49 GMT",
+      "Content-Type",
+      "application/xml; charset=utf-8",
+      "Transfer-Encoding",
+      "chunked",
+      "Connection",
+      "close",
+      "X-Api-Version",
+      "2.0",
+      "Content-Language",
+      "en-US",
+      "X-RateLimit-Limit",
+      "2000",
+      "X-RateLimit-Remaining",
+      "1998",
+      "X-RateLimit-Reset",
+      "1481658360",
+      "Location",
+      "https://unit-test.recurly.com/v2/accounts/test_account1",
+      "Cache-Control",
+      "max-age=0, private, must-revalidate",
+      "X-UA-Compatible",
+      "IE=Edge",
+      "Strict-Transport-Security",
+      "max-age=15552000; includeSubDomains; preload",
+      "Server",
+      "cloudflare-nginx"
+    ]
+  }
+]

--- a/test/cassettes/accounts#get.json
+++ b/test/cassettes/accounts#get.json
@@ -1,0 +1,40 @@
+[
+  {
+    "scope": "https://unit-test.recurly.com:443",
+    "method": "GET",
+    "path": "/v2/accounts/test_account1",
+    "body": "",
+    "status": 200,
+    "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<account href=\"https://unit-test.recurly.com/v2/accounts/test_account1\">\n  <adjustments href=\"https://unit-test.recurly.com/v2/accounts/test_account1/adjustments\"/>\n  <invoices href=\"https://unit-test.recurly.com/v2/accounts/test_account1/invoices\"/>\n  <subscriptions href=\"https://unit-test.recurly.com/v2/accounts/test_account1/subscriptions\"/>\n  <transactions href=\"https://unit-test.recurly.com/v2/accounts/test_account1/transactions\"/>\n  <account_code>test_account1</account_code>\n  <state>active</state>\n  <username nil=\"nil\"></username>\n  <email nil=\"nil\"></email>\n  <cc_emails nil=\"nil\"></cc_emails>\n  <first_name nil=\"nil\"></first_name>\n  <last_name nil=\"nil\"></last_name>\n  <company_name nil=\"nil\"></company_name>\n  <vat_number nil=\"nil\"></vat_number>\n  <address>\n    <address1 nil=\"nil\"></address1>\n    <address2 nil=\"nil\"></address2>\n    <city nil=\"nil\"></city>\n    <state nil=\"nil\"></state>\n    <zip nil=\"nil\"></zip>\n    <country nil=\"nil\"></country>\n    <phone nil=\"nil\"></phone>\n  </address>\n  <accept_language nil=\"nil\"></accept_language>\n  <hosted_login_token>85fc92131fe6dd730f3ec49232a2abf5</hosted_login_token>\n  <created_at type=\"datetime\">2016-12-13T19:41:49Z</created_at>\n  <closed_at nil=\"nil\"></closed_at>\n</account>\n",
+    "rawHeaders": [
+      "Date",
+      "Tue, 13 Dec 2016 19:43:58 GMT",
+      "Content-Type",
+      "application/xml; charset=utf-8",
+      "Transfer-Encoding",
+      "chunked",
+      "Connection",
+      "close",
+      "Vary",
+      "Accept-Encoding",
+      "X-Api-Version",
+      "2.0",
+      "Content-Language",
+      "en-US",
+      "X-RateLimit-Limit",
+      "2000",
+      "X-RateLimit-Remaining",
+      "1997",
+      "X-RateLimit-Reset",
+      "1481658480",
+      "Cache-Control",
+      "max-age=0, private, must-revalidate",
+      "X-UA-Compatible",
+      "IE=Edge",
+      "Strict-Transport-Security",
+      "max-age=15552000; includeSubDomains; preload",
+      "Server",
+      "cloudflare-nginx"
+    ]
+  }
+]

--- a/test/cassettes/accounts#get_not_found.json
+++ b/test/cassettes/accounts#get_not_found.json
@@ -1,0 +1,38 @@
+[
+  {
+    "scope": "https://unit-test.recurly.com:443",
+    "method": "GET",
+    "path": "/v2/accounts/not_found",
+    "body": "",
+    "status": 404,
+    "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<error>\n  <symbol>not_found</symbol>\n  <description lang=\"en-US\">Couldn't find Account with account_code = not_found</description>\n</error>\n",
+    "rawHeaders": [
+      "Date",
+      "Wed, 14 Dec 2016 17:26:52 GMT",
+      "Content-Type",
+      "application/xml; charset=utf-8",
+      "Transfer-Encoding",
+      "chunked",
+      "Connection",
+      "close",
+      "Vary",
+      "Accept-Encoding",
+      "X-Api-Version",
+      "2.0",
+      "Content-Language",
+      "en-US",
+      "X-RateLimit-Limit",
+      "2000",
+      "X-RateLimit-Remaining",
+      "1999",
+      "X-RateLimit-Reset",
+      "1481736660",
+      "Cache-Control",
+      "no-cache",
+      "Strict-Transport-Security",
+      "max-age=15552000; includeSubDomains; preload",
+      "Server",
+      "cloudflare-nginx"
+    ]
+  }
+]

--- a/test/cassettes/billingInfo#get.json
+++ b/test/cassettes/billingInfo#get.json
@@ -1,0 +1,40 @@
+[
+  {
+    "scope": "https://unit-test.recurly.com:443",
+    "method": "GET",
+    "path": "/v2/accounts/test_account1/billing_info",
+    "body": "",
+    "status": 200,
+    "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<billing_info href=\"https://unit-test.recurly.com/v2/accounts/test_account1/billing_info\" type=\"credit_card\">\n  <account href=\"https://unit-test.recurly.com/v2/accounts/test_account1\"/>\n  <first_name>Some</first_name>\n  <last_name>Dude</last_name>\n  <company nil=\"nil\"></company>\n  <address1 nil=\"nil\"></address1>\n  <address2 nil=\"nil\"></address2>\n  <city nil=\"nil\"></city>\n  <state nil=\"nil\"></state>\n  <zip>55401</zip>\n  <country nil=\"nil\"></country>\n  <phone nil=\"nil\"></phone>\n  <vat_number nil=\"nil\"></vat_number>\n  <ip_address>63.146.31.74</ip_address>\n  <ip_address_country>US</ip_address_country>\n  <card_type>Visa</card_type>\n  <year type=\"integer\">2019</year>\n  <month type=\"integer\">10</month>\n  <first_six>411111</first_six>\n  <last_four>1111</last_four>\n</billing_info>\n",
+    "rawHeaders": [
+      "Date",
+      "Thu, 15 Dec 2016 20:43:40 GMT",
+      "Content-Type",
+      "application/xml; charset=utf-8",
+      "Transfer-Encoding",
+      "chunked",
+      "Connection",
+      "close",
+      "Vary",
+      "Accept-Encoding",
+      "X-Api-Version",
+      "2.0",
+      "Content-Language",
+      "en-US",
+      "X-RateLimit-Limit",
+      "2000",
+      "X-RateLimit-Remaining",
+      "1997",
+      "X-RateLimit-Reset",
+      "1481834880",
+      "Cache-Control",
+      "max-age=0, private, must-revalidate",
+      "X-UA-Compatible",
+      "IE=Edge",
+      "Strict-Transport-Security",
+      "max-age=15552000; includeSubDomains; preload",
+      "Server",
+      "cloudflare-nginx"
+    ]
+  }
+]

--- a/test/cassettes/billingInfo#get_not_found.json
+++ b/test/cassettes/billingInfo#get_not_found.json
@@ -1,0 +1,38 @@
+[
+  {
+    "scope": "https://unit-test.recurly.com:443",
+    "method": "GET",
+    "path": "/v2/accounts/not_found",
+    "body": "",
+    "status": 404,
+    "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<error>\n  <symbol>not_found</symbol>\n  <description lang=\"en-US\">Couldn't find Account with account_code = not_found</description>\n</error>\n",
+    "rawHeaders": [
+      "Date",
+      "Thu, 15 Dec 2016 20:44:37 GMT",
+      "Content-Type",
+      "application/xml; charset=utf-8",
+      "Transfer-Encoding",
+      "chunked",
+      "Connection",
+      "close",
+      "Vary",
+      "Accept-Encoding",
+      "X-Api-Version",
+      "2.0",
+      "Content-Language",
+      "en-US",
+      "X-RateLimit-Limit",
+      "2000",
+      "X-RateLimit-Remaining",
+      "1996",
+      "X-RateLimit-Reset",
+      "1481834940",
+      "Cache-Control",
+      "no-cache",
+      "Strict-Transport-Security",
+      "max-age=15552000; includeSubDomains; preload",
+      "Server",
+      "cloudflare-nginx"
+    ]
+  }
+]

--- a/test/cassettes/billingInfo#update.json
+++ b/test/cassettes/billingInfo#update.json
@@ -1,0 +1,40 @@
+[
+  {
+    "scope": "https://unit-test.recurly.com:443",
+    "method": "PUT",
+    "path": "/v2/accounts/test_account1/billing_info",
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<billing_info>\n\t<token_id>be9eBzdi_t-PB9Ym9nADKg</token_id>\n</billing_info>",
+    "status": 201,
+    "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<billing_info href=\"https://unit-test.recurly.com/v2/accounts/test_account1/billing_info\" type=\"credit_card\">\n  <account href=\"https://unit-test.recurly.com/v2/accounts/test_account1\"/>\n  <first_name>Some</first_name>\n  <last_name>Dude</last_name>\n  <company nil=\"nil\"></company>\n  <address1 nil=\"nil\"></address1>\n  <address2 nil=\"nil\"></address2>\n  <city nil=\"nil\"></city>\n  <state nil=\"nil\"></state>\n  <zip>55401</zip>\n  <country nil=\"nil\"></country>\n  <phone nil=\"nil\"></phone>\n  <vat_number nil=\"nil\"></vat_number>\n  <ip_address>63.146.31.74</ip_address>\n  <ip_address_country>US</ip_address_country>\n  <card_type>Visa</card_type>\n  <year type=\"integer\">2019</year>\n  <month type=\"integer\">10</month>\n  <first_six>411111</first_six>\n  <last_four>1111</last_four>\n</billing_info>\n",
+    "rawHeaders": [
+      "Date",
+      "Thu, 15 Dec 2016 20:41:02 GMT",
+      "Content-Type",
+      "application/xml; charset=utf-8",
+      "Transfer-Encoding",
+      "chunked",
+      "Connection",
+      "close",
+      "X-Api-Version",
+      "2.0",
+      "Content-Language",
+      "en-US",
+      "X-RateLimit-Limit",
+      "2000",
+      "X-RateLimit-Remaining",
+      "1998",
+      "X-RateLimit-Reset",
+      "1481834760",
+      "Location",
+      "https://unit-test.recurly.com/v2/accounts/test_account1/billing_info",
+      "Cache-Control",
+      "max-age=0, private, must-revalidate",
+      "X-UA-Compatible",
+      "IE=Edge",
+      "Strict-Transport-Security",
+      "max-age=15552000; includeSubDomains; preload",
+      "Server",
+      "cloudflare-nginx"
+    ]
+  }
+]

--- a/test/cassettes/plans#list.json
+++ b/test/cassettes/plans#list.json
@@ -1,0 +1,42 @@
+[
+  {
+    "scope": "https://unit-test.recurly.com:443",
+    "method": "GET",
+    "path": "/v2/plans",
+    "body": "",
+    "status": 200,
+    "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<plans type=\"array\">\n  <plan href=\"https://unit-test.recurly.com/v2/plans/annual1\">\n    <add_ons href=\"https://unit-test.recurly.com/v2/plans/annual1/add_ons\"/>\n    <plan_code>annual1</plan_code>\n    <name>Annual Subscription</name>\n    <description>The Premium Subscription description. This is the discounted monthly price that is paid annually.</description>\n    <success_url>https://some.domain.com/checkout/success/</success_url>\n    <cancel_url nil=\"nil\"></cancel_url>\n    <display_donation_amounts type=\"boolean\">false</display_donation_amounts>\n    <display_quantity type=\"boolean\">false</display_quantity>\n    <display_phone_number type=\"boolean\">false</display_phone_number>\n    <bypass_hosted_confirmation type=\"boolean\">true</bypass_hosted_confirmation>\n    <unit_name>unit</unit_name>\n    <payment_page_tos_link nil=\"nil\"></payment_page_tos_link>\n    <plan_interval_length type=\"integer\">12</plan_interval_length>\n    <plan_interval_unit>months</plan_interval_unit>\n    <trial_interval_length type=\"integer\">0</trial_interval_length>\n    <trial_interval_unit>days</trial_interval_unit>\n    <total_billing_cycles nil=\"nil\"></total_billing_cycles>\n    <accounting_code>annual1</accounting_code>\n    <setup_fee_accounting_code></setup_fee_accounting_code>\n    <created_at type=\"datetime\">2016-12-06T20:55:16Z</created_at>\n    <unit_amount_in_cents>\n      <USD type=\"integer\">5882</USD>\n    </unit_amount_in_cents>\n    <setup_fee_in_cents>\n      <USD type=\"integer\">0</USD>\n    </setup_fee_in_cents>\n  </plan>\n  <plan href=\"https://unit-test.recurly.com/v2/plans/monthly1\">\n    <add_ons href=\"https://unit-test.recurly.com/v2/plans/monthly1/add_ons\"/>\n    <plan_code>monthly1</plan_code>\n    <name>Monthly Subscription</name>\n    <description>The Premium Subscription monthly. This is the full price per month.</description>\n    <success_url>https://some.domain.com/checkout/success/</success_url>\n    <cancel_url nil=\"nil\"></cancel_url>\n    <display_donation_amounts type=\"boolean\">false</display_donation_amounts>\n    <display_quantity type=\"boolean\">false</display_quantity>\n    <display_phone_number type=\"boolean\">false</display_phone_number>\n    <bypass_hosted_confirmation type=\"boolean\">true</bypass_hosted_confirmation>\n    <unit_name>unit</unit_name>\n    <payment_page_tos_link nil=\"nil\"></payment_page_tos_link>\n    <plan_interval_length type=\"integer\">1</plan_interval_length>\n    <plan_interval_unit>months</plan_interval_unit>\n    <trial_interval_length type=\"integer\">0</trial_interval_length>\n    <trial_interval_unit>days</trial_interval_unit>\n    <total_billing_cycles nil=\"nil\"></total_billing_cycles>\n    <accounting_code>monthly1</accounting_code>\n    <setup_fee_accounting_code></setup_fee_accounting_code>\n    <created_at type=\"datetime\">2016-12-01T06:36:25Z</created_at>\n    <unit_amount_in_cents>\n      <USD type=\"integer\">897</USD>\n    </unit_amount_in_cents>\n    <setup_fee_in_cents>\n      <USD type=\"integer\">0</USD>\n    </setup_fee_in_cents>\n  </plan>\n</plans>\n",
+    "rawHeaders": [
+      "Date",
+      "Fri, 16 Dec 2016 16:48:08 GMT",
+      "Content-Type",
+      "application/xml; charset=utf-8",
+      "Transfer-Encoding",
+      "chunked",
+      "Connection",
+      "close",
+      "Vary",
+      "Accept-Encoding",
+      "X-Api-Version",
+      "2.0",
+      "Content-Language",
+      "en-US",
+      "X-RateLimit-Limit",
+      "2000",
+      "X-RateLimit-Remaining",
+      "1999",
+      "X-RateLimit-Reset",
+      "1481907180",
+      "X-Records",
+      "2",
+      "Cache-Control",
+      "max-age=0, private, must-revalidate",
+      "X-UA-Compatible",
+      "IE=Edge",
+      "Strict-Transport-Security",
+      "max-age=15552000; includeSubDomains; preload",
+      "Server",
+      "cloudflare-nginx"
+    ]
+  }
+]

--- a/test/cassettes/subscriptions#create.json
+++ b/test/cassettes/subscriptions#create.json
@@ -1,0 +1,40 @@
+[
+  {
+    "scope": "https://unit-test.recurly.com:443",
+    "method": "POST",
+    "path": "/v2/subscriptions",
+    "body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<subscription>\n\t<plan_code>monthly1</plan_code>\n\t<currency>USD</currency>\n\t<account>\n\t\t<account_code>test_account1</account_code>\n\t</account>\n</subscription>",
+    "status": 201,
+    "response": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<subscription href=\"https://unit-test.recurly.com/v2/subscriptions/3a73123a1d3931cc329f994db5a2b680\">\n  <account href=\"https://unit-test.recurly.com/v2/accounts/test_account1\"/>\n  <invoice href=\"https://unit-test.recurly.com/v2/invoices/1020\"/>\n  <plan href=\"https://unit-test.recurly.com/v2/plans/monthly1\">\n    <plan_code>monthly1</plan_code>\n    <name>Monthly Subscription</name>\n  </plan>\n  <uuid>3a73123a1d3931cc329f994db5a2b680</uuid>\n  <state>active</state>\n  <unit_amount_in_cents type=\"integer\">897</unit_amount_in_cents>\n  <currency>USD</currency>\n  <quantity type=\"integer\">1</quantity>\n  <activated_at type=\"datetime\">2016-12-15T20:57:57Z</activated_at>\n  <canceled_at nil=\"nil\"></canceled_at>\n  <expires_at nil=\"nil\"></expires_at>\n  <total_billing_cycles nil=\"nil\"></total_billing_cycles>\n  <remaining_billing_cycles nil=\"nil\"></remaining_billing_cycles>\n  <current_period_started_at type=\"datetime\">2016-12-15T20:57:57Z</current_period_started_at>\n  <current_period_ends_at type=\"datetime\">2017-01-15T20:57:57Z</current_period_ends_at>\n  <trial_started_at nil=\"nil\"></trial_started_at>\n  <trial_ends_at nil=\"nil\"></trial_ends_at>\n  <terms_and_conditions nil=\"nil\"></terms_and_conditions>\n  <customer_notes nil=\"nil\"></customer_notes>\n  <po_number nil=\"nil\"></po_number>\n  <net_terms type=\"integer\">0</net_terms>\n  <collection_method>automatic</collection_method>\n  <subscription_add_ons type=\"array\">\n  </subscription_add_ons>\n  <a name=\"cancel\" href=\"https://unit-test.recurly.com/v2/subscriptions/3a73123a1d3931cc329f994db5a2b680/cancel\" method=\"put\"/>\n  <a name=\"terminate\" href=\"https://unit-test.recurly.com/v2/subscriptions/3a73123a1d3931cc329f994db5a2b680/terminate\" method=\"put\"/>\n  <a name=\"postpone\" href=\"https://unit-test.recurly.com/v2/subscriptions/3a73123a1d3931cc329f994db5a2b680/postpone\" method=\"put\"/>\n  <a name=\"notes\" href=\"https://unit-test.recurly.com/v2/subscriptions/3a73123a1d3931cc329f994db5a2b680/notes\" method=\"put\"/>\n</subscription>\n",
+    "rawHeaders": [
+      "Date",
+      "Thu, 15 Dec 2016 20:57:58 GMT",
+      "Content-Type",
+      "application/xml; charset=utf-8",
+      "Transfer-Encoding",
+      "chunked",
+      "Connection",
+      "close",
+      "X-Api-Version",
+      "2.0",
+      "Content-Language",
+      "en-US",
+      "X-RateLimit-Limit",
+      "2000",
+      "X-RateLimit-Remaining",
+      "1996",
+      "X-RateLimit-Reset",
+      "1481835720",
+      "Location",
+      "https://unit-test.recurly.com/v2/subscriptions/3a73123a1d3931cc329f994db5a2b680",
+      "Cache-Control",
+      "max-age=0, private, must-revalidate",
+      "X-UA-Compatible",
+      "IE=Edge",
+      "Strict-Transport-Security",
+      "max-age=15552000; includeSubDomains; preload",
+      "Server",
+      "cloudflare-nginx"
+    ]
+  }
+]

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -1,0 +1,55 @@
+'use strict'
+const client = require('../lib/client')
+const Xml2js = require('xml2js')
+const chai = require('chai')
+const expect = chai.expect
+const sinon = require('sinon')
+
+const exampleConfig = {
+  SUBDOMAIN: 'sub',
+  API_KEY: 'api-key',
+  DEBUG: true,
+  API_VERSION: 2
+}
+
+describe('client', () => {
+  let parserStub
+
+  beforeEach(() => {
+    parserStub = sinon.stub(Xml2js, 'Parser')
+  })
+
+  afterEach(() => {
+    parserStub.restore()
+  })
+
+  describe('#create', () => {
+    it('should pass default arguments', () => {
+      client.create(exampleConfig)
+      const args = parserStub.firstCall.args[0]
+      expect(args.explicitArray).to.be.false
+    })
+
+    it('should pass also custom Xml2Js arguments', () => {
+      exampleConfig.XML2JS_OPTIONS = {
+        explicitArray: false,
+        ignoreAttrs:true,
+        emptyTag: null,
+        valueProcessors: [
+          'parseNumbers',
+          'parseBooleans'
+        ]
+      }
+
+      client.create(exampleConfig)
+      const args = parserStub.firstCall.args[0]
+      expect(args.explicitArray).to.be.false
+      expect(args.ignoreAttrs).to.be.true
+      expect(args.emptyTag).to.be.null
+      expect(args.valueProcessors).to.deep.equal([
+        Xml2js.processors.parseNumbers,
+        Xml2js.processors.parseBooleans
+      ])
+    })
+  })
+})

--- a/test/config-example.js
+++ b/test/config-example.js
@@ -1,7 +1,16 @@
 module.exports = {
 	API_KEY: '',
-	SUBDOMAIN:    '',
-	ENVIRONMENT:  'sandbox',
-	DEBUG: true,
-	API_VERSION: 2
-};
+	SUBDOMAIN: 'unit-test',
+	ENVIRONMENT: 'sandbox',
+	DEBUG: false,
+	API_VERSION: 2,
+  XML2JS_OPTIONS: {
+    explicitArray: false,
+    ignoreAttrs:true,
+    emptyTag: null,
+    valueProcessors: [
+      'parseNumbers',
+      'parseBooleans'
+    ]
+  }
+}

--- a/test/originaltest.js
+++ b/test/originaltest.js
@@ -1,7 +1,10 @@
-var Recurly = require('../'),
-	config = require('./config-example'),
-	recurly = new Recurly(config),
-	utils = require('../lib/utils');
+'use strict'
+
+// var Recurly = require('../'),
+//   config = require('./config-example'),
+//   recurly = new Recurly(config),
+//   utils = require('../lib/utils');
+//
 
 // recurly.accounts.list(function(res){
 // 	console.log(res);
@@ -55,8 +58,13 @@ var Recurly = require('../'),
 // 	console.log(res);
 // })
 
-// recurly.coupons.create({coupon_code: 'test', name: 'Test name', discount_type: 'percent', discount_percent: 20}, function(res){
-// 	console.log(res);
+// recurly.coupons.create({
+//     coupon_code: 'test',
+//     name: 'Test name',
+//     discount_type: 'percent',
+//     discount_percent: 20},
+//   function(res){
+// 	  console.log(res);
 // })
 
 // recurly.coupons.deactivate('test', function(res){
@@ -103,8 +111,9 @@ var Recurly = require('../'),
 // 	console.log(res);
 // })
 
-// recurly.planAddons.create('premium', { add_on_code: 'test', name: 'Test', unit_amount_in_cents: { EUR: 10 } }, function(res){
-// 	console.log(res);
+// recurly.planAddons.create('premium', {
+//   add_on_code: 'test', name: 'Test', unit_amount_in_cents: { EUR: 10 } }, function(res){
+// 	console.log(res)
 // })
 
 // recurly.planAddons.get('premium', 'test', function(res){
@@ -132,32 +141,32 @@ var Recurly = require('../'),
 // })
 
 // recurly.subscriptions.create(
-// 	{plan_code: 'premium', 
-// 	account: 1, 
+// 	{plan_code: 'premium',
+// 	account: 1,
 // 	currency: 'EUR',
 // 	account: {
-// 		account_code: 1, 
+// 		account_code: 1,
 // 		billing_info: {
 // 			number: '4111-1111-1111-1111',
 // 			first_name: 'Ivan',
 // 			last_name: 'Guardado'
-// 		} 
+// 		}
 // 	}
 // }, function(res){
 // 	console.log(res);
 // })
 
 // recurly.subscriptions.preview(
-// 	{plan_code: 'premium', 
-// 	account: 1, 
+// 	{plan_code: 'premium',
+// 	account: 1,
 // 	currency: 'EUR',
 // 	account: {
-// 		account_code: 1, 
+// 		account_code: 1,
 // 		billing_info: {
 // 			number: '4111-1111-1111-1111',
 // 			first_name: 'Ivan',
 // 			last_name: 'Guardado'
-// 		} 
+// 		}
 // 	}
 // }, function(res){
 // 	console.log(res);

--- a/test/plans_test.js
+++ b/test/plans_test.js
@@ -1,0 +1,22 @@
+'use strict'
+// const Promise = require('bluebird')
+const Recurly = require('../promise')
+const config = require('./config-example')
+const recurly = new Recurly(config)
+const chai = require('chai')
+const expect = chai.expect
+const vcr = require('./vcr_setup')
+
+describe('plans', () => {
+  describe('#list', () => {
+    it('should list all plans with no filter', () => {
+      return vcr.useCassette('plans#list', () => {
+        return recurly.plans.list().then((res) => {
+          expect(res.statusCode).to.equal(200)
+          const plans = res.data.plans.plan
+          expect(plans.length).to.eq(2)
+        })
+      })
+    })
+  })
+})

--- a/test/subscriptions_test.js
+++ b/test/subscriptions_test.js
@@ -1,0 +1,30 @@
+'use strict'
+// const Promise = require('bluebird')
+const Recurly = require('../promise')
+const config = require('./config-example')
+const recurly = new Recurly(config)
+const chai = require('chai')
+const expect = chai.expect
+const vcr = require('./vcr_setup')
+
+describe('subscriptions', () => {
+  describe('#create', () => {
+    it('should create a subscription with minimum required values', () => {
+      return vcr.useCassette('subscriptions#create', () => {
+        return recurly.subscriptions.create({
+          plan_code: 'monthly1',
+          currency: 'USD',
+          account: {
+            account_code: 'test_account1'
+          }
+        })
+        .then((res) => {
+          // console.log(JSON.stringify(res, null, 2))
+          expect(res.statusCode).to.equal(201)
+          const data = res.data.subscription
+          expect(data.uuid).to.eq('3a73123a1d3931cc329f994db5a2b680')
+        })
+      })
+    })
+  })
+})

--- a/test/vcr_setup.js
+++ b/test/vcr_setup.js
@@ -1,0 +1,8 @@
+'use strict'
+const path = require('path')
+const vcr = require('nock-vcr-recorder')
+vcr.config({
+  cassetteLibraryDir: path.join(__dirname, 'cassettes')
+})
+
+module.exports = vcr


### PR DESCRIPTION
It was tough to know what exactly what form the responses would take when passed through the xml parser and ultimate to the callback or Promise resolver, so I wrote out some tests.

I also added an option to the config to be able to pass options to the Xml2Js parser for issue #4.

Lastly, I cleaned up the code per the lint rules. I went with JSCS, but left the jshint config file. Is there a reason there are both of them?