### PR TITLE
Replaced UTF-8 encoded response string with encoding agnostic buffer …

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -42,12 +42,12 @@ exports.create = function (config) {
       that.debug(options);
       var req = https.request(options, function (res) {
 
-        var responsedata = '';
+        var responsedata = [];
         res.on('data', function (d) {
-          responsedata += d;
+          responsedata.push(d);
         });
         res.on('end', function () {
-          responsedata = that.trim(responsedata);
+          responsedata = Buffer.concat(responsedata);
           that.debug('Response is: ' + res.statusCode);
           that.debug(responsedata);
           try {
@@ -140,19 +140,7 @@ exports.create = function (config) {
       if (config.DEBUG) {
         console.log(s);
       }
-    },
-
-    trim: function (str) {
-      str = str.replace(/^\s+/, '');
-      for (var i = str.length - 1; i >= 0; i--) {
-        if (/\S/.test(str.charAt(i))) {
-          str = str.substring(0, i + 1);
-          break;
-        }
-      }
-      return str;
     }
-
   };
 };
 


### PR DESCRIPTION
Using string concatenation for response data assumes UTF-8 encoding. When binary data is sent (as in a PDF) it ends up corrupting the data. By using a buffer and concatenating the chunks, the encoding of the originally sent response is maintained, UTF-8 or otherwise.