### PR TITLE
For all response status over 400, parse the response body as XML.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -71,7 +71,9 @@ exports.create = function (config) {
               });
             }
             if (res.statusCode >= 400) {
-              return _cb(res, responsedata);
+              return parser.parseString(responsedata, function (err, result) {
+                return _cb(res, result);
+              });
             }
           }
           catch (e) {


### PR DESCRIPTION
For any response statuses other than 404, 412, 422, 500, the request function is returning a Buffer object as response data instead of a parse object. After this change, all responses above 400 will return a parsed object to the callback function.