### PR TITLE
Add support for specific minor version of the API.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -20,6 +20,7 @@ exports.create = function (config) {
         path: endpoint,
         method: method,
         headers: {
+          'X-Api-Version': config.API_VERSION,
           Authorization: 'Basic ' + (new Buffer(config.API_KEY)).toString('base64'),
           Accept: 'application/xml',
           'Content-Length': (data) ? Buffer.byteLength(data, 'utf8') : 0,
@@ -143,4 +144,3 @@ exports.create = function (config) {
     }
   };
 };
-

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -6,8 +6,10 @@ var routes = {
 
 
 exports.routes = function (version) {
-  if (routes['v' + version]) {
-    return routes['v' + version];
+  var matches = /(\d+)\.\d+/.exec(version);
+  var major = (matches ? matches[ 1 ] : version);
+  if (routes['v' + major]) {
+    return routes['v' + major];
   } else {
     throw new Error('The API version v' + version + ' is not available!');
   }


### PR DESCRIPTION
The current version doesn't work if you configure it with a minor version (e.g. "2.4"). This fix handles minor versions properly by: 1) choosing the correct router version and 2) add the X-Api-Version header to the API requests.