### PR TITLE
Add support for XML2JS_OPTIONS (simple compatible change)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -3,10 +3,10 @@
 var https = require('https');
 var pjson = require('../package.json');
 var Xml2js = require('xml2js');
-var parser = new Xml2js.Parser({explicitArray: false});
 
 exports.create = function (config) {
   config.RECURLY_HOST = config.SUBDOMAIN + '.recurly.com';
+  var parser = new Xml2js.Parser(config.XML2JS_OPTIONS || { explicitArray: false });
   return {
 
     request: function (route, callback, data) {

--- a/test/config-example.js
+++ b/test/config-example.js
@@ -1,7 +1,16 @@
 module.exports = {
-	API_KEY: '',
-	SUBDOMAIN:    '',
-	ENVIRONMENT:  'sandbox',
-	DEBUG: true,
-	API_VERSION: 2
+  API_KEY: '',
+  SUBDOMAIN:    '',
+  ENVIRONMENT:  'sandbox',
+  DEBUG: true,
+  API_VERSION: 2,
+  XML2JS_OPTIONS: {
+    explicitArray: false,
+    ignoreAttrs:true,
+    emptyTag: null,
+    valueProcessors: [
+      'parseNumbers',
+      'parseBooleans'
+    ]
+  }
 };


### PR DESCRIPTION
This PR adds `XML2JS_OPTIONS` so it can be used today in a backwards compatible way and will work consistently when https://github.com/umayr/recurly-js/pull/12 is finally merged.  There is a lot of good stuff in that PR, but it has been sitting um-merged for a while now.

@umayr Our team would very much appreciated it if this could be released ASAP. If there is any additional help you need or have concerns please let me know! :+1: 