### PR TITLE
Change user agent string to identify the library.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -23,7 +23,7 @@ exports.create = function (config) {
           Authorization: 'Basic ' + (new Buffer(config.API_KEY)).toString('base64'),
           Accept: 'application/xml',
           'Content-Length': (data) ? Buffer.byteLength(data, 'utf8') : 0,
-          'User-Agent': 'recurly-js/' + pjson.version
+          'User-Agent': 'umayr/recurly-node/' + pjson.version
         }
       };
 


### PR DESCRIPTION
I had a hard time explaining recurly support that I wasn't using the reculy-js lib because of the user agent, so here's a fix to that.

closes #24 