### PR TITLE
Parse response data if error are >= 400.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -71,7 +71,9 @@ exports.create = function (config) {
               });
             }
             if (res.statusCode >= 400) {
-              return _cb(res, responsedata);
+              return parser.parseString(responsedata, function (err, result) {
+                return _cb(res, result);
+              });
             }
           }
           catch (e) {


### PR DESCRIPTION
Recurly returns XML strings for this types of errors, which may be also parsed to JS object.