### PR TITLE
Add support for creating purchases

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,14 @@ http://docs.recurly.com/api/plans/add-ons
     recurly.planAddons.update(plancode, addoncode, details, callback)
     recurly.planAddons.remove(plancode, addoncode, callback)
 
+Purchases
+=========
+https://dev.recurly.com/docs/create-purchase
+
+    recurly.purchases.create(details, callback)
+
+  The purchase endpoint requires API version v2.6. Creating multiple subscriptions requires
+  API v2.8, and some extra feature flags enabled. Contact Recurly support for more details.
 
 Transactions
 ===============

--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -246,6 +246,12 @@ module.exports = function(config) {
     }
   };
 
+  this.purchases = {
+    create: function(details, callback) {
+      t.request(routes.purchases.create, callback, js2xmlparser('purchase', details));
+    }
+  };
+
   this.subscriptions = {
     list: function(callback, filter) {
       t.request(utils.addQueryParams(routes.subscriptions.list, filter), callback);

--- a/lib/routes/v2.js
+++ b/lib/routes/v2.js
@@ -68,6 +68,10 @@ exports.planAddons = {
   remove: ['/v2/plans/:plan_code/add_ons/:add_on_code', 'DELETE']
 };
 
+exports.purchases = {
+  create: ['/v2/purchases', 'POST']
+};
+
 exports.subscriptions = {
   list: ['/v2/subscriptions', 'GET'],
   listByAccount: ['/v2/accounts/:account_code/subscriptions', 'GET'],


### PR DESCRIPTION
This uses the new purchases API, to allow for tidy billing of multiple subscriptions. Fixes #35 

This is a very flexible API for all sorts of things, but as an example, calling it to set up two subscriptions together looks like:

```js
const Recurly = require('recurly-js/promise');
const recurly = new Recurly({
	API_KEY: 'APIKEY',
	SUBDOMAIN: 'SUBDOMAIN',
	API_VERSION: '2.11'
});

recurly.purchases.create({
	account: { account_code: 'ACCOUNTCODE' },
	currency: 'USD',
	subscriptions: {
		subscription: [
			{ plan_code: 'planA' },
			{ plan_code: 'planB' }
		]
	}
})
.then((d) => console.log('done', d.data))
.catch(console.error);
```