### PR TITLE
fix: adds alias to match recurly api docs

### DIFF
--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -183,10 +183,16 @@ module.exports = function(config) {
       }), callback, js2xmlparser('transaction', details));
     },
     exportPdf: function(invoicenumber, callback) {
+      // TOOO: Remove this function after introducing deprecated notice
       t.request(utils.addParams(routes.invoices.retrievePdf, {
         invoice_number: invoicenumber
       }), callback);
-    }
+    },
+    retrievePdf: function(invoicenumber, callback) {
+      t.request(utils.addParams(routes.invoices.retrievePdf, {
+        invoice_number: invoicenumber
+      }), callback);
+    },
   };
 
   this.plans = {


### PR DESCRIPTION
Hey there.

It looks like there's a slight mismatch between the API exposed here and the one documented in the README.md and [Recurly](https://dev.recurly.com/docs/retrieve-a-pdf-invoice).

I've created an additional and duplicate method to avoid breaking anyone's current implementation.


