### PR TITLE
get all invoice redemptions

### DIFF
--- a/lib/routes/v2.js
+++ b/lib/routes/v2.js
@@ -35,7 +35,8 @@ exports.couponRedemption = {
   get: ['/v2/accounts/:account_code/redemption', 'GET'],
   getAll: ['/v2/accounts/:account_code/redemptions', 'GET'],
   remove: ['/v2/accounts/:account_code/redemption', 'DELETE'],
-  getByInvoice: ['/v2/invoices/:invoice_number/redemption', 'GET']
+  getByInvoice: ['/v2/invoices/:invoice_number/redemption', 'GET'],
+  getAllByInvoice: ['/v2/invoices/:invoice_number/redemptions', 'GET']
 };
 
 exports.invoices = {


### PR DESCRIPTION
The single invoice redemption api has been deprecated,  with new API endpoint to get all redemptions in an invoice
https://dev.recurly.com/docs/lookup-a-coupon-redemption-on-an-invoice